### PR TITLE
Fix issue #18

### DIFF
--- a/almeval/datasets/ds_asr.py
+++ b/almeval/datasets/ds_asr.py
@@ -11,10 +11,9 @@ class ASRDataset(AudioBaseDataset):
     TASK = 'ASR'
     LANG = None
 
-    def meta(self):
-        meta = super().meta()
-        meta['lang'] = self.LANG
-        return meta
+    def __init__(self):
+        super().__init__()
+        self.meta['lang'] = self.LANG
 
     def evaluate(self, eval_file, dump_judge=True, method='qwen2-audio-impl'):
         # ASR always use qwen2-audio-impl


### PR DESCRIPTION
Hi, this PR is the quick fix for issue #18  assert error when eval qwen model.

The error originates from incorrect writing in the `Kimi-Audio-Evalkit/almeval/datasets/ds_asr.py` file.
In the original implementation, 'lang' was not added to the meta dict of the base class.
This will not cause any problems when evaluating other models, but it will trigger an error when evaluating qwen (because only qwen needs lang in the meta)
<img width="494" height="281" alt="image" src="https://github.com/user-attachments/assets/63cfb38e-d6c4-4287-add8-6d4f6747b0a6" />

